### PR TITLE
Validate wallet connection, exit when wallet is not connected

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,18 @@ runs:
 
     - name: Verify Auth Token
       shell: bash
-      run: |-
-        bls whoami
+      run: |
+        output=$(bls whoami 2>&1)
+        exit_code=$?
+
+        if [ $exit_code -eq 0 ]; then
+          if [[ $output == "Wallet is currently disconnected"* ]]; then
+            echo "Authentication token is invalid."
+            exit 1
+          else
+            echo "Authentication token is valid."
+          fi
+        else
+          echo "Authentication token is invalid."
+          exit 1
+        fi


### PR DESCRIPTION
This PR prevents displaying the `bls whoami` output, instead validates the wallet connection and provides an exit code if the wallet is not connected, preventing the next job execution.